### PR TITLE
fix: forgot to remove the previous MapLayer & cleaning code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,15 +18,8 @@ type Props = {
 // are passed upstream with the `onCornersUpdated` method
 export default class ReactDistortableImageOverlay extends React.Component {
 
-  state = {
-    corners: [L.latlng, L.latlng, L.latlng, L.latlng],
-  }
-
   constructor(props) {
     super(props);
-    this.state = { 
-      corners: props.corners
-    }
   }
 
   onUpdate(corners) {
@@ -46,9 +39,7 @@ export default class ReactDistortableImageOverlay extends React.Component {
       this.props.onWellKnownTextUpdated('POLYGON((' + flattenedLatLngs.join(', ') + '))');
     }
 
-    this.setState({
-      corners: corners
-    });
+    //this.props.corners = corners
   }
 
   render() {
@@ -57,7 +48,7 @@ export default class ReactDistortableImageOverlay extends React.Component {
       <ReactDistortableImageOverlayMapLayer 
         url={this.props.url}
         opacity={this.props.opacity}
-        corners={this.state.corners}
+        corners={this.props.corners}
         editMode={this.props.editMode}
         onUpdate={this.onUpdate.bind(this)}
       />

--- a/src/react-distortable-imageoverlay-maplayer.js
+++ b/src/react-distortable-imageoverlay-maplayer.js
@@ -18,7 +18,7 @@ class ReactDistortableImageOverlayMapLayer extends MapLayer<LeafletElement, Prop
 	createLeafletElement(props: Props): LeafletElement {
 		this.distortableImage = new L.DistortableImageOverlay(props.url, this.getOptions(props));
 		this.originalCorners = props.corners;
-
+		//console.log("Creato Leaflet element")
 
 		L.DomEvent.on(this.distortableImage, 'load', () => {
 			this.distortableImage._image.style.opacity = this.props.opacity;
@@ -38,12 +38,13 @@ class ReactDistortableImageOverlayMapLayer extends MapLayer<LeafletElement, Prop
 		if (fromProps.corners !== toProps.corners) {
 			console.log('Corners changed!')
 		} else {
-			console.log('Corners did not change!')
+			//console.log('Corners did not change!')
 		}
 
 
  		// Keep map ref before removing so we can addLayer when the LeafletElement is recreated
 		var map = this.distortableImage._map;
+		map.removeLayer(this.distortableImage)
 		this.distortableImage.onRemove();
 
 		// The translation state behaves differently from the rotate and distort (uses leaflet-path-transform)
@@ -53,7 +54,7 @@ class ReactDistortableImageOverlayMapLayer extends MapLayer<LeafletElement, Prop
 			this.translateUpdateCorners = undefined;
 		} else {
 			this.distortableImage = new L.DistortableImageOverlay(toProps.url, this.getOptions(toProps));
-		}2
+		}
 
 		// Apply opacity after the image loads
 		L.DomEvent.on(this.distortableImage, 'load', () => {


### PR DESCRIPTION
On row 47: + map.removeLayer(this.distortableImage)
Now every time the component is updating it remove the previous leaflet Map Layer. Without this fix if you change the render props it will always add a new Leaflet Layer that increase the memory.

On row 57: there was a '2', it was a typing error I suppose. I deleted it.

On Index.js I removed the corner state because I prefer to pass them to the <ReactDistortableImageOverlayMapLayer /> child component as a props and not as a state.